### PR TITLE
Add deck recall functionality

### DIFF
--- a/backend/src/MyRoom.ts
+++ b/backend/src/MyRoom.ts
@@ -62,6 +62,8 @@ export class MyRoom extends Room {
             let card = deck.takeTopCard()!;
             this.state.table.addNewCard(
                 card, new Vector(message.cardX, message.cardY));
+        } else if (message.messageType === "recall_to_deck") {
+            this.state.recallToDeck(message.deckId);
         }
     }
 

--- a/frontend/src/DeckComponent.css
+++ b/frontend/src/DeckComponent.css
@@ -6,6 +6,32 @@
     border-radius: 5%;
     margin: 8px;
     background-color: #55a;
-    color: white;
-    font-size: 40px;
+}
+
+.inner-deck {
+    height: 100%;
+    width: 100%;
+    color: #eee;
+    font-size: 12px;
+}
+
+.inner-deck div {
+    margin-top: 45px;
+    text-align: center;
+}
+
+
+.deck button {
+    font-weight: bold;
+    font-size: 20px;
+    color: #ddd;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: none;
+    float: right;
+}
+
+.deck button:hover {
+    color: #fff;
 }

--- a/frontend/src/DeckComponent.tsx
+++ b/frontend/src/DeckComponent.tsx
@@ -4,13 +4,27 @@ import "./DeckComponent.css";
 
 type Props = {
     deck: Deck,
+    sendMessage: (msg: any) => void,
+    onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void,
 }
 
 export default class DeckComponent extends React.Component<Props, {}> {
+    private recallToThisDeck() {
+        this.props.sendMessage({
+            messageType: "recall_to_deck",
+            deckId: this.props.deck.id,
+        });
+    }
+
     public render() {
         return (
             <div className="deck">
-                {this.props.deck.cards.length}
+                <button onClick={this.recallToThisDeck.bind(this)}>&#8942;</button>
+            <div className="inner-deck" onClick={this.props.onClick}>
+                <div>
+                    {this.props.deck.cards.length} cards
+                </div>
+            </div>
             </div>
         );
     }

--- a/frontend/src/DecksComponent.tsx
+++ b/frontend/src/DecksComponent.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export default class DecksComponent extends React.Component<Props, {}> {
-    private onDeckClick(id: number, event: any) {
+    private onDeckClick(id: number, event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
         this.props.sendMessage({
             messageType: "pick_from_deck",
             deckId: id,
@@ -23,9 +23,11 @@ export default class DecksComponent extends React.Component<Props, {}> {
             <ul className="decks">
                 {
                     this.props.decks.map((deck, i) =>
-                        <div onClick={(event) =>
-                            this.onDeckClick(i, event)}>
-                            <DeckComponent key={i} deck={deck} />
+                        <div key={deck.id}>
+                            <DeckComponent deck={deck}
+                                           onClick={(event) =>
+                                               this.onDeckClick(deck.id, event)}
+                                           sendMessage={this.props.sendMessage}/>
                         </div>)
                 }
             </ul>

--- a/library/src/state/Deck.ts
+++ b/library/src/state/Deck.ts
@@ -29,6 +29,16 @@ export class Deck {
         card.deckId = this.id;
         this.cards.push(card);
     }
+
+    addAll(cards: Card[]) {
+        for (let card of cards) {
+            this.addToTop(card);
+        }
+    }
+
+    shuffleDeck() {
+        this.cards = shuffle(this.cards);
+    }
 }
 
 export function shuffledStandardDeck() : Deck {

--- a/library/src/state/State.ts
+++ b/library/src/state/State.ts
@@ -46,10 +46,23 @@ export class State {
     }
 
     public getDeck(id: number): Deck | null {
-        if (id >= this.decks.length || id < 0) {
-            return null
+        for (let deck of this.decks) {
+            if (deck.id === id) {
+                return deck;
+            }
         }
-        return this.decks[id];
+
+        return null;
+    }
+
+    public recallToDeck(deckId: number) {
+        let deck = this.getDeck(deckId);
+
+        if (deck !== null) {
+            let cards = this.table.removeCardsBelongingToDeck(deckId);
+
+            deck.addAll(cards);
+        }
     }
 }
 

--- a/library/src/state/Table.ts
+++ b/library/src/state/Table.ts
@@ -39,4 +39,48 @@ export default class Table {
             new LocatedCard(card, location,
                             this.getHighestZIndex() + 1));
     }
+
+    public removeCardsBelongingToDeck(deckId: number): Card[] {
+        let cards = [];
+        let cardIndices = [];
+
+        for (let i = 0; i < this.locatedCards.length; i++) {
+            if (this.locatedCards[i].card.deckId === deckId) {
+                cards.push(this.locatedCards[i].card);
+                cardIndices.push(i);
+            }
+        }
+
+        this.locatedCards =
+            this.removeSortedIndices(this.locatedCards, cardIndices);
+
+        return cards;
+    }
+
+    /**
+     * Remove all `indices` from list, and return the new list.
+     *
+     ***********************************************
+     ***** ONLY WORKS IF: `indices` is sorted. *****
+     ***********************************************
+     *
+     */
+    private removeSortedIndices<T>(list: T[], indices: number[]): T[] {
+        if (indices.length === 0) {
+            return list;
+        }
+
+        let newList = [];
+        let j = 0;
+
+        for (let i = 0; i < list.length; i++) {
+            if (indices.length <= j || i !== indices[j]) {
+                newList.push(list[i]);
+            } else {
+                j++;
+            }
+        }
+
+        return newList;
+    }
 }


### PR DESCRIPTION
Recalling a deck is currently achieved by clicking the three dots on
the deck. In the future these 3 dots will open a menu were various
operations can be done (such as shuffle).

Fixes #32