### PR TITLE
Let users choose name

### DIFF
--- a/backend/src/MyRoom.ts
+++ b/backend/src/MyRoom.ts
@@ -76,6 +76,12 @@ export class MyRoom extends Room {
             this.state.removeDeck(message.deckId);
         } else if (message.messageType === "return_card_to_deck") {
             this.state.returnCardToDeck(message.cardId);
+        } else if (message.messageType === "update_player_name") {
+            let player = this.state.getPlayer(message.playerId);
+            if(player !== null) {
+                player.name = message.username;
+                this.state.updatePlayer(player!);        
+            }
         }
     }
 

--- a/backend/src/MyRoom.ts
+++ b/backend/src/MyRoom.ts
@@ -118,9 +118,8 @@ export class MyRoom extends Room {
             this.state.returnCardToDeck(message.cardId);
         } else if (message.messageType === "update_player_name") {
             let player = this.state.getPlayer(message.playerId);
-            if(player !== null) {
+            if (player !== null) {
                 player.name = message.username;
-                this.state.updatePlayer(player!);        
             }
         }
     }

--- a/backend/src/MyRoom.ts
+++ b/backend/src/MyRoom.ts
@@ -19,8 +19,9 @@ export class MyRoom extends Room {
         let hand: Card[] = [];
         let pointer : Vector = new Vector(0, 0);
         let player = new Player(client.id, hand, pointer, client.id);
-
         this.state.addPlayer(player);
+
+        this.send(client, {messageType: "request_username_update"});
     }
 
     onMessage (client: Client, message: any) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,9 +46,16 @@ export default class App extends React.Component<Props, AppState> {
         room.onStateChange(this.updateRoomState.bind(this));
 
         // listen to patches coming from the server
-        room.onMessage(function(message) {
-            console.log("New message", message);
-        });
+        room.onMessage(this.handleIncomingMessage.bind(this));
+    }
+
+    private handleIncomingMessage(message: any) {
+        switch(message.messageType) {
+            default : {
+                console.error("Message type not supported", message)
+                break;
+            }
+        }
     }
 
     private updateRoomState(state: any) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,12 @@ export default class App extends React.Component<Props, AppState> {
 
     private handleIncomingMessage(message: any) {
         switch(message.messageType) {
+            case "request_username_update": {
+                console.log(message);
+                console.log(this);
+                this.usernamePopUp();
+                break;
+            }
             default : {
                 console.error("Message type not supported", message)
                 break;
@@ -79,6 +85,13 @@ export default class App extends React.Component<Props, AppState> {
                 pointerY: e.clientY,
             });
         }
+    }
+    private usernamePopUp(){
+        let username = prompt("Please enter your username", "Player " + (this.state.gameState.players.length+1));
+        let msg = {messageType: "update_player_name", 
+                   username: username,
+                   playerId: this.state.currentPlayerId}
+        this.sendMessage(msg);
     }
 
     public render() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import './App.css';
 import * as Colyseus from "colyseus.js";
 import {State, initialState} from "cards-library";
 import TableComponent from "./TableComponent";
+import HeaderComponent from "./HeaderComponent";
 import RoomHelper from "./RoomHelper";
 import PointersComponent from "./PointersComponent";
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -12,7 +13,8 @@ type Props = {};
 
 type AppState = {
     gameState: State,
-    currentPlayerId: string;
+    currentPlayerId: string,
+    headerComponentRef: React.RefObject<HeaderComponent>,
 };
 
 
@@ -24,6 +26,7 @@ export default class App extends React.Component<Props, AppState> {
         this.state = {
             gameState: initialState(),
             currentPlayerId: "",
+            headerComponentRef: React.createRef(),
         };
     }
 
@@ -54,9 +57,11 @@ export default class App extends React.Component<Props, AppState> {
     private handleIncomingMessage(message: any) {
         switch(message.messageType) {
             case "request_username_update": {
-                console.log(message);
-                console.log(this);
-                this.usernamePopUp();
+                let headerComponent =
+                    this.state.headerComponentRef.current;
+                if (headerComponent !== null) {
+                    headerComponent.onNameChange();
+                }
                 break;
             }
             default : {
@@ -88,17 +93,15 @@ export default class App extends React.Component<Props, AppState> {
             });
         }
     }
-    private usernamePopUp(){
-        let username = prompt("Please enter your username", "Player " + (this.state.gameState.players.length+1));
-        let msg = {messageType: "update_player_name", 
-                   username: username,
-                   playerId: this.state.currentPlayerId}
-        this.sendMessage(msg);
-    }
 
     public render() {
         return (
             <div className="App" onMouseMove={this.onMouseMove.bind(this)}>
+                <HeaderComponent
+                    ref={this.state.headerComponentRef}
+                    sendMessage={this.sendMessage.bind(this)}
+                    players={this.state.gameState.players}
+                    currentPlayerId={this.state.currentPlayerId} />
                 <PointersComponent players={this.state.gameState.players}
                                    currentPlayerId={this.state.currentPlayerId}/>
                 <TableComponent decks={this.state.gameState.decks}

--- a/frontend/src/HeaderComponent.tsx
+++ b/frontend/src/HeaderComponent.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import Navbar from 'react-bootstrap/Navbar';
+import Form from 'react-bootstrap/Form';
+import {Player} from "cards-library";
+
+type Props = {
+    sendMessage: (msg: any) => void,
+    players: Player[],
+    currentPlayerId: string,
+};
+
+export default class HeaderComponent extends React.Component<Props> {
+    playerNameRef: any;
+
+    constructor(props: Props) {
+        super(props);
+        this.playerNameRef = React.createRef();
+    }
+
+    public onNameChange() {
+        this.props.sendMessage({
+            messageType: "update_player_name",
+            username: this.getGivenPlayerName(),
+            playerId: this.props.currentPlayerId,
+        });
+    }
+
+    private getGivenPlayerName() {
+        let input = this.playerNameRef.current;
+        return input && input.value ?
+               input.value : this.defaultPlayerName();
+    }
+
+    private getPlayerNum() : number {
+        for (let i = 0; i < this.props.players.length; i++) {
+            if (this.props.players[i].id === this.props.currentPlayerId) {
+                return i+1;
+            }
+        }
+        return -1;
+    }
+
+    private defaultPlayerName() : string {
+        return "Player " + this.getPlayerNum();
+    }
+
+    public render() {
+        this.onNameChange();
+        return (
+            <Navbar bg="light">
+                <Navbar.Brand href="/">PlayCardsWith.Me</Navbar.Brand>
+                <Navbar.Collapse>
+                    <Form inline>
+                        <Form.Control
+                            ref={this.playerNameRef}
+                            type="text"
+                            placeholder={this.defaultPlayerName()}
+                            onChange={this.onNameChange.bind(this)} />
+                    </Form>
+                </Navbar.Collapse>
+            </Navbar>
+        );
+    }
+}

--- a/library/src/state/State.ts
+++ b/library/src/state/State.ts
@@ -14,15 +14,6 @@ export class State {
         this.players = players;
     }
 
-    public updatePlayer(player: Player) {
-        let index = this.getPlayerIndex(player.id);
-        if (index !== null) {
-            this.players[index] = player;
-        } else {
-            console.log(`Player {$player} was not found and could therefore not be updated`);
-        }
-    }
-
     addPlayer(player: Player) {
         this.players.push(player);
     }

--- a/library/src/state/State.ts
+++ b/library/src/state/State.ts
@@ -14,6 +14,15 @@ export class State {
         this.players = players;
     }
 
+    public updatePlayer(player: Player) {
+        let index = this.getPlayerIndex(player.id);
+        if (index !== null) {
+            this.players[index] = player;
+        } else {
+            console.log(`Player {$player} was not found and could therefore not be updated`);
+        }
+    }
+
     addPlayer(player: Player) {
         this.players.push(player);
     }


### PR DESCRIPTION
Fix #9 

This PR allows for username update via prompt on client side. The action is triggered when the user first joins the room. 

Can use a prettier prompt UI.
Would make sense to display the usernames in the frontend.
Can use a edit button for usernames in UI for editing after initial joining of room.
  