### PR TITLE
Fix bug where cards where rendered incorrectly

### DIFF
--- a/frontend/src/OwnHandComponent.tsx
+++ b/frontend/src/OwnHandComponent.tsx
@@ -19,11 +19,12 @@ export default class OwnHandComponent extends React.Component<Props> {
             <div className="ownHand" ref={this.props.handRef}>
                 <p>Your hand:</p>
                 {this.props.cards.map((card, index) => {
-                     return (<HandCardComponent
-                                 card={card}
-                                 sendMessage={this.props.sendMessage}
-                                 location={this.locationFor(index)}
-                                 handRef={this.props.handRef} />);
+                    return (<HandCardComponent
+                                key={"handcard-"+card.id}
+                                card={card}
+                                sendMessage={this.props.sendMessage}
+                                location={this.locationFor(index)}
+                                handRef={this.props.handRef} />);
                  })}
             </div>
         );


### PR DESCRIPTION
Because the components didn't have a key the state was saved on index
instead of card. Now they do have a key and state is properly shared. Specifically the draggedoutofhand was taken over from the card that had been dragged out of the hand.

Fixes #78 