### PR TITLE
Don't refresh the page when pressing Enter on entering your name

### DIFF
--- a/frontend/src/HeaderComponent.tsx
+++ b/frontend/src/HeaderComponent.tsx
@@ -46,6 +46,14 @@ export default class HeaderComponent extends React.Component<Props> {
         return "Player " + this.getPlayerNum();
     }
 
+    private onSubmitForNameInput(e:any) {
+        //Avoid refreshing the page
+        e.preventDefault();
+
+        //Deselect the text input (esp. important on mobile)
+        e.target[0].blur();
+    }
+
     public render() {
         this.onNameChange();
         return (
@@ -56,7 +64,7 @@ export default class HeaderComponent extends React.Component<Props> {
                                  className="justify-content-end">
                     <Row>
                         <Col>
-                            <Form inline>
+                            <Form inline onSubmit={this.onSubmitForNameInput}>
                                 <Form.Group>
                                     <Form.Label>Your name: </Form.Label>
                                     <FormControl


### PR DESCRIPTION
Closes #92

Very small issue, but it's nice to have a fix anyway as it is a bit frustrating if the page refreshes when you enter your name.