### PR TITLE
Add special cards (basic implementation)

### DIFF
--- a/backend/src/MyRoom.ts
+++ b/backend/src/MyRoom.ts
@@ -119,8 +119,8 @@ export class MyRoom extends Room {
         } else if (message.messageType === "shuffle_deck") {
             this.state.shuffleDeck(message.deckId);
         } else if (message.messageType === "add_deck") {
-            if ((message.amountOfEach * message.includedCards.length
-                * message.includedSuits.length) > 10000) {
+            if ((message.amountOfEach * (message.includedCards.length
+                * message.includedSuits.length + message.includedSpecialCards.length)) > 10000) {
                 console.log("User attempted to create too large deck:",
                             message);
             } else {

--- a/frontend/src/CardComponent.css
+++ b/frontend/src/CardComponent.css
@@ -4,9 +4,6 @@
     transform-style: preserve-3d;
 }
 
-.card-red-suit {
-    color: red;
-}
 
 .cardFaceHolder {
     transform-origin: 40px 0px;
@@ -32,10 +29,6 @@
     line-height: 1;
     font-size: 48px;
     transform: rotateY(180deg);
-}
-
-.card-open-content {
-    vertical-align: center;
 }
 
 .card-closed {

--- a/frontend/src/CardComponent.tsx
+++ b/frontend/src/CardComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Card, Deck} from "cards-library";
 import "./CardComponent.css";
+import CardOpenFaceComponent from "./CardOpenFaceComponent";
 
 type Props = {
     decks: Deck[],
@@ -10,14 +11,6 @@ type Props = {
 };
 
 export default class CardComponent extends React.Component<Props> {
-    private isRedSuit() {
-        let cardName = this.props.card.name;
-
-        let res = cardName.startsWith("♥") ||
-                  cardName.startsWith("♦");
-        return res;
-    }
-
     private getMyDeck() {
         return this.props.decks.filter(
             (d) => d.id === this.props.card.deckId)[0];
@@ -33,10 +26,6 @@ export default class CardComponent extends React.Component<Props> {
         if (this.props.card.open)
             classNamesFaceHolder += "is-flipped ";
 
-        if (this.isRedSuit()) {
-            classNamesFaceHolder += "card-red-suit ";
-        }
-
         let closedStyles = { backgroundColor: this.getBackgroundColor() };
         closedStyles = Object.assign(closedStyles, this.props.stylesCardFace);
         
@@ -45,11 +34,7 @@ export default class CardComponent extends React.Component<Props> {
                  ref={"card"+this.props.card.id} >
                 <div className={classNamesFaceHolder}>
                     <div className="cardFace card-open" style={this.props.stylesCardFace}>
-                        <p className="card-open-content">
-                            {this.props.card.name.slice(0, 1)}
-                            <br></br>
-                            {this.props.card.name.slice(1)}
-                        </p>
+                        <CardOpenFaceComponent cardName={this.props.card.name}></CardOpenFaceComponent>
                     </div>
                     <div className="cardFace card-closed" style={closedStyles}>
                     </div>

--- a/frontend/src/CardOpenFaceComponent.css
+++ b/frontend/src/CardOpenFaceComponent.css
@@ -9,7 +9,7 @@
 .fullCardFace {
     display: flex;
     margin: 5px;
-    height: 100%;
+    height: calc(100% - 10px);
     flex-direction: column;
     justify-content: center;
 }
@@ -18,4 +18,11 @@
     font-size: 18px;
     line-height: normal;
     overflow-wrap: break-word;
+    margin-bottom: 0.63rem;
+}
+
+.card-open-content-special-single {
+    font-size: 90px;
+    /* Hopefully render the black joker correctly (i.e. not as emoji). */
+    font-family: sans-serif;
 }

--- a/frontend/src/CardOpenFaceComponent.css
+++ b/frontend/src/CardOpenFaceComponent.css
@@ -1,0 +1,21 @@
+
+.card-red-suit {
+    color: red;
+}
+
+.card-open-content {
+}
+
+.fullCardFace {
+    display: flex;
+    margin: 5px;
+    height: 100%;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.card-open-content-special {
+    font-size: 18px;
+    line-height: normal;
+    overflow-wrap: break-word;
+}

--- a/frontend/src/CardOpenFaceComponent.tsx
+++ b/frontend/src/CardOpenFaceComponent.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import "./CardOpenFaceComponent.css";
+
+type Props = {
+    cardName: string,
+};
+
+export default class CardOpenFaceComponent extends React.Component<Props> {
+    private isRedSuit() {
+        let cardName = this.props.cardName;
+
+        let res = cardName.startsWith("♥") ||
+                  cardName.startsWith("♦");
+        return res;
+    }
+
+    private isSimpleCard() {
+        let cardName = this.props.cardName;
+
+        return cardName.startsWith("♥") ||
+            cardName.startsWith("♦") ||
+            cardName.startsWith("♣") ||
+            cardName.startsWith("♠");
+    }
+    
+    public render() {
+        var cardClassNames = "card-open-content ";
+
+        if (this.isSimpleCard()) {
+            // For cards with names of two characters, draw
+            // these characters below each other.
+            
+            if (this.isRedSuit()) {
+                cardClassNames += "card-red-suit ";
+            }
+
+            return (
+                <p className={cardClassNames}>
+                    {this.props.cardName.slice(0, 1)}
+                    <br></br>
+                    {this.props.cardName.slice(1)}
+                </p>
+            );
+        } else {
+            // For cards with more than two characters, simply
+            // draw the name
+ 
+            cardClassNames += "card-open-content-special";
+
+            return (
+                <div className="fullCardFace">
+                    <p className={cardClassNames}>
+                        {this.props.cardName}
+                    </p>
+                </div>
+            );
+        }
+    }
+}

--- a/frontend/src/CardOpenFaceComponent.tsx
+++ b/frontend/src/CardOpenFaceComponent.tsx
@@ -10,7 +10,8 @@ export default class CardOpenFaceComponent extends React.Component<Props> {
         let cardName = this.props.cardName;
 
         let res = cardName.startsWith("♥") ||
-                  cardName.startsWith("♦");
+                  cardName.startsWith("♦") ||
+                  cardName == "🂿";
         return res;
     }
 
@@ -26,14 +27,13 @@ export default class CardOpenFaceComponent extends React.Component<Props> {
     public render() {
         var cardClassNames = "card-open-content ";
 
+        if (this.isRedSuit()) {
+            cardClassNames += "card-red-suit ";
+        }
+
         if (this.isSimpleCard()) {
             // For cards with names of two characters, draw
             // these characters below each other.
-            
-            if (this.isRedSuit()) {
-                cardClassNames += "card-red-suit ";
-            }
-
             return (
                 <p className={cardClassNames}>
                     {this.props.cardName.slice(0, 1)}
@@ -45,7 +45,14 @@ export default class CardOpenFaceComponent extends React.Component<Props> {
             // For cards with more than two characters, simply
             // draw the name
  
-            cardClassNames += "card-open-content-special";
+            cardClassNames += "card-open-content-special ";
+
+            //Render a single character bigger
+            //Deal with emojis and other unicode correctly...
+            var unicodeChars = Array.from(this.props.cardName);
+            unicodeChars = unicodeChars.filter(c => c !== "\uFE0E");
+            if (unicodeChars.length === 1)
+                cardClassNames += "card-open-content-special-single ";
 
             return (
                 <div className="fullCardFace">

--- a/frontend/src/CardOpenFaceComponent.tsx
+++ b/frontend/src/CardOpenFaceComponent.tsx
@@ -11,7 +11,7 @@ export default class CardOpenFaceComponent extends React.Component<Props> {
 
         let res = cardName.startsWith("♥") ||
                   cardName.startsWith("♦") ||
-                  cardName == "🂿";
+                  cardName === "🂿";
         return res;
     }
 

--- a/frontend/src/DecksComponent.tsx
+++ b/frontend/src/DecksComponent.tsx
@@ -37,21 +37,47 @@ export default class DecksComponent extends React.Component<Props, State> {
         { value: "9", label: "9" },
         { value: "10", label: "10" },
         { value: "J", label: "Jack" },
+        { value: "C", label: "Knight" },
         { value: "Q", label: "Queen" },
         { value: "K", label: "King" },
         { value: "A", label: "Ace" }]
+    private readonly frenchCardOptions =
+        this.allCardOptions.filter(c => c.value != "C");
     private readonly allSuitOptions = [
         { value: "♠", label: "♠ Clubs" },
         { value: "♣", label: "♣ Clovers" },
         { value: "♥", label: "♥ Hearts" },
         { value: "♦", label: "♦ Diamonds" }]
     private readonly allSpecialCardOptions = [
-        { value: "Red Joker", label: "Red Joker" },
-        { value: "Black Joker", label: "Black Joker" },
+        { value: "🂿", label: "Red Joker" },
+        { value: "🃏\uFE0E", label: "Black Joker" },
+        { value: "🃟", label: "White Joker" },
         { value: "1", label: "One" },
         { value: "Dog", label: "Dog" },
         { value: "Phoenix", label: "Phoenix" },
-        { value: "Dragon", label: "Dragon" }]
+        { value: "Dragon", label: "Dragon" },
+        { value: "🃡", label: "🃡 Individual" },
+        { value: "🃢", label: "🃢 Childhood" },
+        { value: "🃣", label: "🃣 Youth" },
+        { value: "🃤", label: "🃤 Maturity" },
+        { value: "🃥", label: "🃥 Old Age" },
+        { value: "🃦", label: "🃦 Morning" },
+        { value: "🃧", label: "🃧 Afternoon" },
+        { value: "🃨", label: "🃨 Evening" },
+        { value: "🃩", label: "🃩 Night" },
+        { value: "🃪", label: "🃪 Earth & Air" },
+        { value: "🃫", label: "🃫 Water & Fire" },
+        { value: "🃬", label: "🃬 Dance" },
+        { value: "🃭", label: "🃭 Shopping" },
+        { value: "🃮", label: "🃮 Open air" },
+        { value: "🃯", label: "🃯 Visual arts" },
+        { value: "🃰", label: "🃰 Spring" },
+        { value: "🃱", label: "🃱 Summer" },
+        { value: "🃲", label: "🃲 Autumn" },
+        { value: "🃳", label: "🃳 Winter" },
+        { value: "🃴", label: "🃴 The game" },
+        { value: "🃵", label: "🃵 Collective" },
+        { value: "🃠", label: "🃠 Fool" }]
     private readonly possibleColors = [
             "#b90e0e",
             "#b9690e",
@@ -84,7 +110,7 @@ export default class DecksComponent extends React.Component<Props, State> {
     private defaultNewDeckState() {
         return {
             show: false,
-            includedCards: this.allCardOptions,
+            includedCards: this.frenchCardOptions,
             includedSuits: this.allSuitOptions,
             includedSpecialCards: [],
             amountOfEach: 1,
@@ -204,7 +230,7 @@ export default class DecksComponent extends React.Component<Props, State> {
                                     onChange={this.handleIncludedSpecialCardsChanged.bind(this)}
                                     isMulti={true} />
                                 <Form.Text className="text-muted">
-                                    Jokers etc.
+                                    Jokers, Tarot Nouveau etc.
                                 </Form.Text>
                             </Form.Group>
                             <Form.Group controlId="amountOfEach" >

--- a/frontend/src/DecksComponent.tsx
+++ b/frontend/src/DecksComponent.tsx
@@ -42,7 +42,7 @@ export default class DecksComponent extends React.Component<Props, State> {
         { value: "K", label: "King" },
         { value: "A", label: "Ace" }]
     private readonly frenchCardOptions =
-        this.allCardOptions.filter(c => c.value != "C");
+        this.allCardOptions.filter(c => c.value !== "C");
     private readonly allSuitOptions = [
         { value: "♠", label: "♠ Clubs" },
         { value: "♣", label: "♣ Clovers" },

--- a/frontend/src/DecksComponent.tsx
+++ b/frontend/src/DecksComponent.tsx
@@ -19,6 +19,7 @@ type State = {
     show: boolean,
     includedCards: any[],
     includedSuits: any[],
+    includedSpecialCards: any[],
     amountOfEach: number,
     deckColor: string,
     shuffleDeck: boolean,
@@ -44,6 +45,9 @@ export default class DecksComponent extends React.Component<Props, State> {
         { value: "♣", label: "♣ Clovers" },
         { value: "♥", label: "♥ Hearts" },
         { value: "♦", label: "♦ Diamonds" }]
+    private readonly allSpecialCardOptions = [
+        { value: "Red Joker", label: "Red Joker" },
+        { value: "Black Joker", label: "Black Joker" }]
     private readonly possibleColors = [
             "#b90e0e",
             "#b9690e",
@@ -78,6 +82,7 @@ export default class DecksComponent extends React.Component<Props, State> {
             show: false,
             includedCards: this.allCardOptions,
             includedSuits: this.allSuitOptions,
+            includedSpecialCards: [],
             amountOfEach: 1,
             deckColor: this.possibleColors[this.props.decks.length
                 % this.possibleColors.length],
@@ -96,8 +101,9 @@ export default class DecksComponent extends React.Component<Props, State> {
     }
 
     private getNextTotalCards() {
-        return (this.state.includedCards.length
-            * this.state.includedSuits.length
+        return ((this.state.includedCards.length
+                * this.state.includedSuits.length
+                + this.state.includedSpecialCards.length)
             * this.state.amountOfEach);
     }
 
@@ -106,11 +112,15 @@ export default class DecksComponent extends React.Component<Props, State> {
     }
 
     private handleIncludedCardsChanged(selectedOptions: any) {
-        this.setState({ includedCards: selectedOptions });
+        this.setState({ includedCards: selectedOptions ?? [] });
     }
 
     private handleIncludedSuitsChanged(selectedOptions: any) {
-        this.setState({ includedSuits: selectedOptions });
+        this.setState({ includedSuits: selectedOptions ?? [] });
+    }
+
+    private handleIncludedSpecialCardsChanged(selectedOptions: any) {
+        this.setState({ includedSpecialCards: selectedOptions ?? [] });
     }
 
     private handleAmountOfEachChanged(event: any) {
@@ -126,6 +136,7 @@ export default class DecksComponent extends React.Component<Props, State> {
             messageType: "add_deck",
             includedCards: this.state.includedCards.map((o) => o.value),
             includedSuits: this.state.includedSuits.map((o) => o.value),
+            includedSpecialCards: this.state.includedSpecialCards.map((o) => o.value),
             amountOfEach: this.state.amountOfEach,
             deckColor: this.state.deckColor,
             shuffleDeck: this.state.shuffleDeck,
@@ -177,6 +188,20 @@ export default class DecksComponent extends React.Component<Props, State> {
                                     options={this.allSuitOptions}
                                     onChange={this.handleIncludedSuitsChanged.bind(this)}
                                     isMulti={true} />
+                            </Form.Group>
+                            <Form.Group controlId="specialCards" >
+                                <Form.Label>
+                                    Special cards
+                                </Form.Label>
+                                <Select
+                                    id="specialCards"
+                                    value={this.state.includedSpecialCards}
+                                    options={this.allSpecialCardOptions}
+                                    onChange={this.handleIncludedSpecialCardsChanged.bind(this)}
+                                    isMulti={true} />
+                                <Form.Text className="text-muted">
+                                    Jokers, Tichu cards, etc.
+                                </Form.Text>
                             </Form.Group>
                             <Form.Group controlId="amountOfEach" >
                                 <Form.Label>

--- a/frontend/src/DecksComponent.tsx
+++ b/frontend/src/DecksComponent.tsx
@@ -47,7 +47,11 @@ export default class DecksComponent extends React.Component<Props, State> {
         { value: "♦", label: "♦ Diamonds" }]
     private readonly allSpecialCardOptions = [
         { value: "Red Joker", label: "Red Joker" },
-        { value: "Black Joker", label: "Black Joker" }]
+        { value: "Black Joker", label: "Black Joker" },
+        { value: "1", label: "One" },
+        { value: "Dog", label: "Dog" },
+        { value: "Phoenix", label: "Phoenix" },
+        { value: "Dragon", label: "Dragon" }]
     private readonly possibleColors = [
             "#b90e0e",
             "#b9690e",
@@ -200,7 +204,7 @@ export default class DecksComponent extends React.Component<Props, State> {
                                     onChange={this.handleIncludedSpecialCardsChanged.bind(this)}
                                     isMulti={true} />
                                 <Form.Text className="text-muted">
-                                    Jokers, Tichu cards, etc.
+                                    Jokers etc.
                                 </Form.Text>
                             </Form.Group>
                             <Form.Group controlId="amountOfEach" >

--- a/frontend/src/TableCardComponent.tsx
+++ b/frontend/src/TableCardComponent.tsx
@@ -138,6 +138,7 @@ export default class TableCardComponent extends React.Component<Props, State> {
 
         let styles = {
             zIndex: this.props.locatedCard.zIndex,
+            position: "absolute" as "absolute",
         };
 
         let playingCardClasses = "playing-card ";

--- a/library/src/state/Deck.ts
+++ b/library/src/state/Deck.ts
@@ -75,14 +75,20 @@ function standardCards() : Card[] {
 
 export function newDeck(message: any) : Deck {
     let cards = [];
-    for (let c = 0; c < message.includedCards.length; c++) {
-        for (let s = 0; s < message.includedSuits.length; s++) {
-            for (let i = 0; i < message.amountOfEach; i++) {
+    for (let i = 0; i < message.amountOfEach; i++) {
+        for (let c = 0; c < message.includedCards.length; c++) {
+            for (let s = 0; s < message.includedSuits.length; s++) {
                 cards.push(new Card(
                     message.includedSuits[s] +
                         message.includedCards[c],
                     false));
             }
+        }
+
+        for (let s = 0; s < message.includedSpecialCards.length; s++) {
+            cards.push(new Card(
+                message.includedSpecialCards[s],
+                false));
         }
     }
     if (message.shuffleDeck) {


### PR DESCRIPTION
A basic implementation of adding special cards, like jokers. You have to select all these cards individually for now. Later, it would probably be good to have presets.

The exact special cards are hardcoded for now.

Also fixes related bugs:
- Card z-index was no longer rendered correctly
- Removing all included cards or suits crashed the page. 

Closes #114 